### PR TITLE
Update atlas_url instructions in README for latest packer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cd vagrancy-0.0.1-linux-x86_64
 ```
 ### Publishing images
 ##### Via Packer
-Add something like following to your `.json` Packer file. Use `server_address`, *not* `atlas_url`.
+Add something like following to your `.json` Packer file. For Packer versions <= 0.8.2, use `server_address`, *not* `atlas_url`.
 ```
   ...
   "post-processors": [                              
@@ -24,7 +24,7 @@ Add something like following to your `.json` Packer file. Use `server_address`, 
       "type": "atlas",
       "artifact": "myusername/ubuntu",
       "artifact_type": "vagrant.box",
-      "server_address": "http://localhost:8099/",
+      "atlas_url": "http://localhost:8099/",
       "metadata": {
         "provider": "virtualbox",
         "version": "1.0.0"


### PR DESCRIPTION
Looks like "server_address" [was changed](https://github.com/mitchellh/packer/commit/ee1b6a72ea38f05fdbddb90a832f402769d22c32#diff-af7c554e176a542cd5d3eb067ed99749) to "atlas_url" in [Packer 0.8.3](https://github.com/mitchellh/packer/blob/v0.8.3/post-processor/atlas/post-processor.go).

I've updated the README to reflect this.